### PR TITLE
Revert "Bump log4j-api from 2.8.1 to 2.14.0"

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     }
 
     implementation 'org.apache.commons:commons-lang3:3.11'
-    implementation 'org.apache.logging.log4j:log4j-api:2.14.0'
+    implementation 'org.apache.logging.log4j:log4j-api:2.8.1'
     implementation 'com.google.code.gson:gson:2.8.6'
 }


### PR DESCRIPTION
Closes #
Closes #
Closes #

# Changes proposed in this pull request:
-
-
-

Review please
